### PR TITLE
don't send empty send-email param

### DIFF
--- a/lib/adobe_connect/user.rb
+++ b/lib/adobe_connect/user.rb
@@ -19,8 +19,8 @@ module AdobeConnect
     def attrs
       atrs = { :first_name => first_name,
         :last_name => last_name, :login => username,
-        :email => email, :send_email => send_email,
-        :has_children => 0 }
+        :email => email, :has_children => 0 }
+      atrs[:send_email] = send_email unless send_email.nil?
       if !self.id.nil?
         atrs.merge!(:principal_id => self.id)
       else

--- a/lib/adobe_connect/version.rb
+++ b/lib/adobe_connect/version.rb
@@ -1,4 +1,4 @@
 module AdobeConnect
   # Public: Current Gem version.
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/test/lib/adobe_connect/user_test.rb
+++ b/test/lib/adobe_connect/user_test.rb
@@ -58,10 +58,12 @@ class AdobeConnectUserTest < AdobeConnectTestCase
   end
 
   def obj_attrs_posted
-    { :first_name => obj_attrs[:first_name],
+    attrs = { :first_name => obj_attrs[:first_name],
       :last_name => obj_attrs[:last_name], :login => @connect_obj.username,
       :password => @connect_obj.password, :type => 'user', :has_children => 0,
-      :email => obj_attrs[:email], :send_email => @connect_obj.send_email }
+      :email => obj_attrs[:email] }
+    attrs[:send_email] = @connect_obj.send_email unless @connect_obj.send_email.nil?
+    attrs
   end
 
   def responses


### PR DESCRIPTION
principal-update has an optional boolean send-email param. setting
it to nothing (like what used to happen when send_email on the
User model was nil) causes adobe to throw an invalid-field error.