### PR TITLE
Add extra query string option in params for Service.request method.

### DIFF
--- a/lib/adobe_connect/service.rb
+++ b/lib/adobe_connect/service.rb
@@ -86,12 +86,9 @@ module AdobeConnect
         params[:session] = session
       end
 
-      if params[:extra_query_string]
-        extra_query_string = params[:extra_query_string]
-        params.delete :extra_query_string
-      end
-
+      extra_query_string = params.delete(:extra_query_string)
       query_string = ParamFormatter.new(params).format
+
       response     = client.get("/api/xml?action=#{action}#{query_string}#{extra_query_string}")
       AdobeConnect::Response.new(response)
     end

--- a/lib/adobe_connect/service.rb
+++ b/lib/adobe_connect/service.rb
@@ -76,6 +76,7 @@ module AdobeConnect
     #
     # action      - The name of the API action to call.
     # params      - A hash of params to pass in the request.
+    #               use :extra_query_string to pass the string which will be inserted at the end of request url
     # use_session - If true, require an active session (default: true).
     #
     # Returns an AdobeConnect::Response.
@@ -85,8 +86,13 @@ module AdobeConnect
         params[:session] = session
       end
 
+      if params[:extra_query_string]
+        extra_query_string = params[:extra_query_string]
+        params.delete :extra_query_string
+      end
+
       query_string = ParamFormatter.new(params).format
-      response     = client.get("/api/xml?action=#{action}#{query_string}")
+      response     = client.get("/api/xml?action=#{action}#{query_string}#{extra_query_string}")
       AdobeConnect::Response.new(response)
     end
   end

--- a/lib/adobe_connect/service.rb
+++ b/lib/adobe_connect/service.rb
@@ -86,7 +86,13 @@ module AdobeConnect
         params[:session] = session
       end
 
-      extra_query_string = params.delete(:extra_query_string)
+      if params[:extra_query_string]
+        extra_query_string = params[:extra_query_string]
+        raise 'Invalid argument. extra_query_string should start with &.' unless extra_query_string.start_with?('&')
+
+        params.delete :extra_query_string
+      end
+
       query_string = ParamFormatter.new(params).format
 
       response     = client.get("/api/xml?action=#{action}#{query_string}#{extra_query_string}")

--- a/lib/adobe_connect/version.rb
+++ b/lib/adobe_connect/version.rb
@@ -1,4 +1,4 @@
 module AdobeConnect
   # Public: Current Gem version.
-  VERSION = '1.0.4'
+  VERSION = '1.0.3'
 end

--- a/lib/adobe_connect/version.rb
+++ b/lib/adobe_connect/version.rb
@@ -1,4 +1,4 @@
 module AdobeConnect
   # Public: Current Gem version.
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
You may need to insert extra query string for example when trying to register participant to an event which has some extra registration questions. Like described here

http://www.connectusers.com/tutorials/2013/09/event_registration_using_adobe_connect_apis/index.php

http://YOURSERVER.adobeconnect.com/api/xml? action=event-register&sco-id=1227409411& login=john@d.com&password=1234& password-verify=1234&first-name=John& last-name=Doe&interaction-id=122558421& response=Doe%20Inc& interaction-id=1227230451&response=6-10

Notice that interaction-id key is used more than once, so can not use params hash, thus I've added that extra param.
