### PR TITLE
Allow for non-datetime objects that respond to :strftime to be in params hash

### DIFF
--- a/lib/adobe_connect/param_formatter.rb
+++ b/lib/adobe_connect/param_formatter.rb
@@ -17,7 +17,10 @@ module AdobeConnect
     # Returns a query string.
     def format
       params.sort_by { |k, v| k.to_s }.inject(['']) do |array, param|
-        param[1] = format_datetime(param[1]) if param[1].respond_to?(:strftime)
+        if param[1].respond_to?(:utc) && param[1].respond_to?(:strftime)
+          param[1] = format_datetime(param[1]) 
+        end
+
         key, value = param.map { |p| ERB::Util.url_encode(p) }
         array << "#{key.dasherize}=#{value}"
       end.join('&')

--- a/lib/adobe_connect/service.rb
+++ b/lib/adobe_connect/service.rb
@@ -80,7 +80,12 @@ module AdobeConnect
     # use_session - If true, require an active session (default: true).
     #
     # Returns an AdobeConnect::Response.
-    def request(action, params={}, use_session = true)
+    def request(action, params, use_session = true)
+
+      # Not sure why using an action with no params isn't defaulting
+      # to the signature default...?
+      params ||= {}
+
       if use_session
         log_in unless authenticated?
         params[:session] = session


### PR DESCRIPTION
Update to allow for objects that respond to strftime to NOT be considered DateTime objects that also respond to :utc.