### PR TITLE
Allow nokogiri 1.12.5

### DIFF
--- a/adobe_connect.gemspec
+++ b/adobe_connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'activesupport', '>= 2.3.17'
-  gem.add_dependency 'nokogiri',      '>= 1.5.5', '< 1.12'
+  gem.add_dependency 'nokogiri',      '>= 1.5.5', '< 1.13'
   gem.add_dependency 'rake',          '>= 0.9.2'
 
   gem.add_development_dependency 'minitest',    '~> 4.6.0'


### PR DESCRIPTION
There is a vulnerability in previous versions of nokogiri.

Advisory: CVE-2021-41098
URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-2rr5-8q37-2w7h
Title: Improper Restriction of XML External Entity Reference (XXE) in Nokogiri on JRuby
Solution: upgrade to >= 1.12.5