### PR TITLE
Relax nokogiri requirement to allow upgdating to 1.14.x

### DIFF
--- a/adobe_connect.gemspec
+++ b/adobe_connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency 'activesupport', '>= 2.3.17'
-  gem.add_dependency 'nokogiri',      '~> 1.13.3'
+  gem.add_dependency 'nokogiri',      '~> 1.13', '>= 1.13.3'
   gem.add_dependency 'rake',          '>= 0.9.2'
 
   gem.add_development_dependency 'minitest',    '~> 4.6.0'


### PR DESCRIPTION
Security vulnerabilities exist prior to 1.14.3 now